### PR TITLE
fix: registry URL command  format in icon-detail-content

### DIFF
--- a/app/icons/[slug]/icon-detail-content.tsx
+++ b/app/icons/[slug]/icon-detail-content.tsx
@@ -157,7 +157,7 @@ export default function IconDetailContent({ slug }: { slug: string }) {
                 <TabsContent value="cli" className="mt-0 space-y-4">
                   <div>
                     <CodeBlock
-                      command={`${LINKS.SITE_URL}/${iconData.name}.json`}
+                      command={`${LINKS.SITE_URL}/r/${iconData.name}.json`}
                       className="w-full"
                     />
                   </div>


### PR DESCRIPTION
## What does this PR do?
This change update the registry URL command by which icons also install through cli command on /icons/[icon-name] page.

before it's ${LINKS.SITE_URL}/${iconData.name}.json but according to folder structure it will be  ${LINKS.SITE_URL}/r/${iconData.name}.json

Fixes: #17 

## Video
https://github.com/user-attachments/assets/a7dd705b-82f1-48b0-8f9b-b8d78de7447c

## How should this be tested?
1. Go to [itshover.com/icons](https://www.itshover.com/icons)
2. Click on any icon
3. Copy CLI command
4. Run the command in your terminal.
