### PR TITLE
Feat: Dynamic Search Keyboard Shortcut Icon

### DIFF
--- a/components/icons-list.tsx
+++ b/components/icons-list.tsx
@@ -6,6 +6,7 @@ import Fuse from "fuse.js";
 import SearchInput, { SearchInputRef } from "./ui/search-input";
 import { motion, AnimatePresence } from "motion/react";
 import Link from "next/link";
+import { isMac } from "@/lib/utils";
 
 const IconList = () => {
   const searchInputRef = useRef<SearchInputRef>(null);
@@ -100,7 +101,7 @@ const IconList = () => {
           ref={searchInputRef}
           value={searchQuery}
           onChange={setSearchQuery}
-          placeholder={`Search ${iconCount} Icons ... (⌘ + F)`}
+          placeholder={`Search ${iconCount} Icons ... (${isMac() ? "⌘" : "Ctrl"} + F)`}
           className="w-full md:w-1/2"
         />
       </motion.div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -12,14 +12,10 @@ import { LINKS } from "@/constants";
 import LayersIcon from "@/icons/layers-icon";
 import AlignCenterIcon from "@/icons/align-center-icon";
 import XIcon from "@/icons/x-icon";
+import { isMac } from "@/lib/utils";
 
 const Navbar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isMac] = useState(() =>
-    typeof navigator !== "undefined"
-      ? navigator.userAgent.toLowerCase().includes("mac")
-      : true,
-  );
   const { toggle: toggleCommandMenu } = useCommandMenu();
 
   const toggleMobileMenu = () => {
@@ -94,7 +90,7 @@ const Navbar = () => {
               className="hover:text-foreground/80 text-foreground/60 w-32 cursor-pointer bg-transparent pr-4 pl-2 text-xs font-medium transition-colors outline-none sm:text-sm xl:w-40"
             />
             <Kbd>
-              <span className="text-xs">{isMac ? "⌘" : "Ctrl+"}</span>K
+              <span className="text-xs">{isMac() ? "⌘" : "Ctrl+"}</span>K
             </Kbd>
           </button>
         </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function isMac() {
+  return typeof navigator !== "undefined"
+    ? navigator.userAgent.toLowerCase().includes("mac")
+    : true;
+}


### PR DESCRIPTION
## Summary

Add dynamic icon for search keyboard shortcut based on client's OS (Mac/Linux)

## Screenshot

- Mac

<img width="596" height="281" alt="image" src="https://github.com/user-attachments/assets/559ecc80-12d3-4318-9df9-19d9c3b95ef5" />

- Linux

<img width="640" height="261" alt="image" src="https://github.com/user-attachments/assets/bc468188-9274-44ab-b995-aa12699ed67e" />
