### PR TITLE
Feat: Command Menu closes on Escape key

### DIFF
--- a/components/cmdk.tsx
+++ b/components/cmdk.tsx
@@ -47,6 +47,7 @@ export const CommandMenu = () => {
         setIsOpen(!isOpen);
       } else if (e.key === "Escape") {
         e.preventDefault();
+        e.stopPropagation();
         setIsOpen(false);
       }
     };


### PR DESCRIPTION
## Summary

Command menu (triggered by Cmd+K / Ctrl+K) now could be closed using the Escape key.

## Changes

- Include an event listener for the Escape key on `cmdk.tsx` component

## Tests

https://github.com/user-attachments/assets/eea73baa-bb42-4ef8-8cff-34678e4deb03



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escape key now closes the command menu, providing a quick way to dismiss it and complementing the existing Ctrl/Cmd+K toggle.
  * Improves keyboard accessibility and usability for users who prefer keyboard navigation when opening or closing the command menu.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->