### PR TITLE
feat: add code-merge-icon with full visible merge path + pulse/scale hover animation

### DIFF
--- a/icons/code-merge-icon.tsx
+++ b/icons/code-merge-icon.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { motion, useAnimate } from "motion/react";
+import { AnimatedIconHandle, AnimatedIconProps } from "./types";
+
+const CodeMergeIcon = forwardRef<AnimatedIconHandle, AnimatedIconProps>(
+  (
+    { size = 24, color = "currentColor", strokeWidth = 2, className = "" },
+    ref,
+  ) => {
+    const [scope, animate] = useAnimate();
+
+    const start = async () => {
+      await animate(
+        "#merge-path",
+        { pathLength: [0, 1], opacity: [0, 1] },
+        { duration: 0.3, ease: "easeOut" },
+      );
+
+      await Promise.all([
+        animate(
+          "#top-circle",
+          { scale: [1, 1.15, 1] },
+          { duration: 0.4, delay: 0.2 },
+        ),
+        animate(
+          "#bottom-circle",
+          { scale: [1, 1.15, 1] },
+          { duration: 0.4, delay: 0.3 },
+        ),
+      ]);
+
+      await animate(".icon-group", { scale: 1.1 }, { duration: 0.3 });
+    };
+
+    const stop = () => {
+      animate("#merge-path", { pathLength: 1, opacity: 1 }, { duration: 0.4 });
+      animate("#top-circle", { scale: 1 }, { duration: 0.25 });
+      animate("#bottom-circle", { scale: 1 }, { duration: 0.25 });
+      animate(".icon-group", { scale: 1 }, { duration: 0.25 });
+    };
+
+    useImperativeHandle(ref, () => ({
+      startAnimation: start,
+      stopAnimation: stop,
+    }));
+
+    return (
+      <motion.svg
+        ref={scope}
+        onHoverStart={start}
+        onHoverEnd={stop}
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`inline-flex cursor-pointer items-center justify-center ${className}`}
+        style={{ overflow: "visible" }}
+      >
+        <motion.g className="icon-group" style={{ transformOrigin: "center" }}>
+          <motion.circle id="top-circle" cx="6" cy="6" r="3" />
+          <motion.circle id="bottom-circle" cx="18" cy="18" r="3" />
+
+          <motion.path
+            id="merge-path"
+            d="M6 21V9a9 9 0 0 0 9 9"
+            pathLength={1}
+            opacity={1}
+          />
+        </motion.g>
+      </motion.svg>
+    );
+  },
+);
+
+CodeMergeIcon.displayName = "CodeMergeIcon";
+export default CodeMergeIcon;

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -184,6 +184,7 @@ import Volume2Icon from "./volume-2-icon";
 import VolumeXIcon from "./volume-x-icon";
 import XIcon from "./x-icon";
 import YoutubeIcon from "./youtube-icon";
+import CodeMergeIcon from "./code-merge-icon";
 
 export interface IconType {
   name: string;
@@ -1350,6 +1351,20 @@ const ICON_LIST: IconType[] = [
       "panel",
       "ui",
       "interface",
+    ],
+  },
+  {
+    name: "code-merge-icon",
+    icon: CodeMergeIcon,
+    keywords: [
+      "code",
+      "merge",
+      "git",
+      "branch",
+      "pull",
+      "request",
+      "combine",
+      "integrate",
     ],
   },
 ].sort((a, b) => a.name.localeCompare(b.name));

--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -647,4 +647,8 @@ export const ICONS = [
     name: "volume x icon",
     path: "/icons/volume-x-icon",
   },
+  {
+    name: "code merge icon",
+    path: "/icons/code-merge-icon",
+  },
 ];

--- a/registry.json
+++ b/registry.json
@@ -940,6 +940,23 @@
       ]
     },
     {
+      "name": "code-merge-icon",
+      "type": "registry:ui",
+      "registryDependencies": [],
+      "dependencies": ["motion"],
+      "devDependencies": [],
+      "files": [
+        {
+          "path": "icons/code-merge-icon.tsx",
+          "type": "registry:ui"
+        },
+        {
+          "path": "icons/types.ts",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "code-xml-icon",
       "type": "registry:ui",
       "registryDependencies": [],


### PR DESCRIPTION
## Description
Adds a new **code-merge-icon** (Git-style branch merging visualization: two circles connected by a curved merge path).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] New icon(s)
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] `npm run check` passes  
- [x] `npm run registry:build` passes (icon registered successfully)
- [x] Icons work on all screen sizes (tested)
- [x] Self-review completed

**Screen recording**  

https://github.com/user-attachments/assets/2c5644b8-4ce8-4b7d-b58c-9717ad2c3156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Code Merge animated icon featuring smooth interactive hover effects
  * Icon is discoverable through development keywords such as code, merge, git, branch, pull request, combine, and integrate

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->