### PR TITLE
fix: layout structure of /example/[slug] page (viewport: 1024px - ~1400px)

### DIFF
--- a/app/example/[slug]/page.tsx
+++ b/app/example/[slug]/page.tsx
@@ -23,7 +23,7 @@ const ExampleDetailPage = async ({ params }: PageProps) => {
     <div className="bg-background text-foreground min-h-screen p-8">
       <div className="mx-auto grid max-w-[1600px] grid-cols-1 gap-12 lg:grid-cols-[1fr_300px]">
         {/* Main Content */}
-        <div className="min-w-0 flex flex-col gap-8">
+        <div className="flex min-w-0 flex-col gap-8">
           {/* Header */}
           <div className="flex flex-col gap-4">
             <h1 className="text-3xl font-bold tracking-tight md:text-5xl">


### PR DESCRIPTION
## Description
This PR fixes a layout issue where the "X Sidebar" component would break the page structure when the "Code" tab was active.

### The Issue
Previously, the CSS Grid layout used `grid-cols-[1fr_300px]`. By default, a CSS Grid item has a `min-width` of `auto`, meaning it cannot shrink smaller than its content. When the "Code" tab is opened, the long lines of code (which do not wrap) force the `1fr` column to expand beyond the viewport width, pushing the sidebar off-screen.

### The Fix
I added `min-w-0` to the main content wrapper (the direct child of the grid).
- **Class added:** `min-w-0`
- **Why:** This overrides the default grid behavior, allowing the container to shrink to fit the available space. This forces the inner Code block to respect the container width and handle its own overflow (scroll) correctly.

https://github.com/user-attachments/assets/53ed6e67-d972-4e6a-b29d-43db2b8ca6e3

### Related Issue
Fixes #52 



## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] New icon(s)
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] `npm run check` passes
- [ ] `npm run registry:build` passes (for new icons)
- [ ] Icons work on all screen sizes
- [x] Self-review completed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced layout constraints to improve content sizing and overflow handling within flexible containers, yielding more reliable rendering across varied content lengths and screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->