### PR TITLE
feat: add command-palette example with animated icons

### DIFF
--- a/components/examples/command-palette.tsx
+++ b/components/examples/command-palette.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
+import HomeIcon from "../ui/home-icon";
+import LayoutDashboardIcon from "../ui/layout-dashboard-icon";
+import PenIcon from "../ui/pen-icon";
+import SendIcon from "../ui/send-icon";
+import BookmarkIcon from "../ui/bookmark-icon";
+import UserCheckIcon from "../ui/user-check-icon";
+import GearIcon from "../ui/gear-icon";
+import LogoutIcon from "../ui/logout-icon";
+import BookIcon from "../ui/book-icon";
+import BugIcon from "../ui/bug-icon";
+import MagnifierIcon from "../ui/magnifier-icon";
+import type { AnimatedIconHandle, AnimatedIconProps } from "../ui/types";
+
+type Command = {
+  category: string;
+  label: string;
+  icon: React.ComponentType<
+    AnimatedIconProps & React.RefAttributes<AnimatedIconHandle>
+  >;
+};
+
+const ALL_COMMANDS: Command[] = [
+  { category: "Navigate", label: "Home", icon: HomeIcon },
+  { category: "Navigate", label: "Dashboard", icon: LayoutDashboardIcon },
+  { category: "Actions", label: "New Post", icon: PenIcon },
+  { category: "Actions", label: "Send Message", icon: SendIcon },
+  { category: "Actions", label: "Bookmarks", icon: BookmarkIcon },
+  { category: "Account", label: "Profile", icon: UserCheckIcon },
+  { category: "Account", label: "Settings", icon: GearIcon },
+  { category: "Account", label: "Sign Out", icon: LogoutIcon },
+  { category: "Help", label: "Documentation", icon: BookIcon },
+  { category: "Help", label: "Report Bug", icon: BugIcon },
+];
+
+interface CommandItemProps {
+  command: Command;
+  isSelected: boolean;
+  isAnimated: boolean;
+  onSelect: () => void;
+  onHover: () => void;
+}
+
+const CommandItem = ({
+  command,
+  isSelected,
+  isAnimated,
+  onSelect,
+  onHover,
+}: CommandItemProps) => {
+  const ref = useRef<AnimatedIconHandle>(null);
+  const { icon: Icon, label } = command;
+
+  const handleMouseEnter = () => {
+    onHover();
+    if (isAnimated) ref.current?.startAnimation();
+  };
+
+  const handleMouseLeave = () => {
+    if (isAnimated) ref.current?.stopAnimation();
+  };
+
+  return (
+    <button
+      className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
+        isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+      }`}
+      onClick={onSelect}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+        <Icon
+          ref={ref}
+          size={18}
+          className="text-muted-foreground"
+          disableHover={!isAnimated}
+        />
+      </span>
+      <span className="flex-1 text-sm">{label}</span>
+    </button>
+  );
+};
+
+interface CommandPaletteProps {
+  isAnimated?: boolean;
+}
+
+const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(
+    () =>
+      query.trim()
+        ? ALL_COMMANDS.filter((c) =>
+            c.label.toLowerCase().includes(query.toLowerCase()),
+          )
+        : ALL_COMMANDS,
+    [query],
+  );
+
+  const grouped = useMemo(
+    () =>
+      query.trim()
+        ? null
+        : ALL_COMMANDS.reduce<Record<string, Command[]>>((acc, cmd) => {
+            if (!acc[cmd.category]) acc[cmd.category] = [];
+            acc[cmd.category].push(cmd);
+            return acc;
+          }, {}),
+    [query],
+  );
+
+  const openPalette = useCallback(() => {
+    setOpen(true);
+    setQuery("");
+    setSelectedIndex(0);
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "p") {
+        e.preventDefault();
+        if (open) {
+          closePalette();
+        } else {
+          openPalette();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, openPalette, closePalette]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        closePalette();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        console.log("Selected:", filtered[selectedIndex]?.label);
+        closePalette();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, filtered, selectedIndex, closePalette]);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(id);
+  }, [open]);
+
+  return (
+    <div className="flex h-64 w-full items-center justify-center">
+      {/* Trigger button */}
+      <button
+        onClick={openPalette}
+        className="border-border bg-muted/50 text-muted-foreground hover:bg-muted flex items-center gap-3 rounded-lg border px-4 py-2.5 text-sm shadow-sm transition-colors"
+      >
+        <MagnifierIcon size={16} disableHover={!isAnimated} />
+        <span>Search commands...</span>
+        <span className="ml-2 flex items-center gap-1">
+          {["⌘", "⇧", "P"].map((key) => (
+            <kbd
+              key={key}
+              className="border-border bg-background rounded border px-1.5 py-0.5 font-mono text-[11px] leading-none"
+            >
+              {key}
+            </kbd>
+          ))}
+        </span>
+      </button>
+
+      {/* Overlay */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[20vh]"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closePalette();
+          }}
+        >
+          <div className="border-border bg-background mx-4 w-full max-w-lg overflow-hidden rounded-xl border shadow-2xl">
+            {/* Search input */}
+            <div className="border-border flex items-center gap-3 border-b px-4 py-3">
+              <MagnifierIcon
+                size={18}
+                className="text-muted-foreground shrink-0"
+                disableHover
+              />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setSelectedIndex(0);
+                }}
+                placeholder="Search commands..."
+                className="placeholder:text-muted-foreground flex-1 bg-transparent text-sm outline-none"
+              />
+              <kbd className="border-border bg-muted text-muted-foreground rounded border px-1.5 py-0.5 font-mono text-[10px]">
+                ESC
+              </kbd>
+            </div>
+
+            {/* Results */}
+            <div className="max-h-80 overflow-y-auto p-2">
+              {filtered.length === 0 ? (
+                <p className="text-muted-foreground py-6 text-center text-sm">
+                  No commands found.
+                </p>
+              ) : query.trim() ? (
+                filtered.map((cmd, i) => (
+                  <CommandItem
+                    key={cmd.label}
+                    command={cmd}
+                    isSelected={i === selectedIndex}
+                    isAnimated={isAnimated}
+                    onSelect={() => {
+                      console.log("Selected:", cmd.label);
+                      closePalette();
+                    }}
+                    onHover={() => setSelectedIndex(i)}
+                  />
+                ))
+              ) : (
+                Object.entries(grouped ?? {}).map(([category, commands]) => (
+                  <div key={category} className="mb-2">
+                    <p className="text-muted-foreground mb-1 px-3 text-[11px] font-medium tracking-wider uppercase">
+                      {category}
+                    </p>
+                    {commands.map((cmd) => {
+                      const globalIndex = ALL_COMMANDS.findIndex(
+                        (c) => c.label === cmd.label,
+                      );
+                      return (
+                        <CommandItem
+                          key={cmd.label}
+                          command={cmd}
+                          isSelected={globalIndex === selectedIndex}
+                          isAnimated={isAnimated}
+                          onSelect={() => {
+                            console.log("Selected:", cmd.label);
+                            closePalette();
+                          }}
+                          onHover={() => setSelectedIndex(globalIndex)}
+                        />
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/components/examples/command-palette.tsx
+++ b/components/examples/command-palette.tsx
@@ -57,7 +57,17 @@ const CommandItem = ({
   onHover,
 }: CommandItemProps) => {
   const ref = useRef<AnimatedIconHandle>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { icon: Icon, label } = command;
+
+  useEffect(() => {
+    if (isSelected) {
+      buttonRef.current?.scrollIntoView({ block: "nearest" });
+      if (isAnimated) ref.current?.startAnimation();
+    } else {
+      ref.current?.stopAnimation();
+    }
+  }, [isSelected, isAnimated]);
 
   const handleMouseEnter = () => {
     onHover();
@@ -70,6 +80,7 @@ const CommandItem = ({
 
   return (
     <button
+      ref={buttonRef}
       className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
         isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
       }`}
@@ -135,7 +146,7 @@ const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "p") {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "p") {
         e.preventDefault();
         if (open) {
           closePalette();
@@ -152,10 +163,11 @@ const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.stopPropagation();
         closePalette();
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+        setSelectedIndex((i) => Math.min(i + 1, Math.max(0, filtered.length - 1)));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setSelectedIndex((i) => Math.max(i - 1, 0));
@@ -202,6 +214,12 @@ const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
           className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[20vh]"
           onClick={(e) => {
             if (e.target === e.currentTarget) closePalette();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              closePalette();
+            }
           }}
         >
           <div className="border-border bg-background mx-4 w-full max-w-lg overflow-hidden rounded-xl border shadow-2xl">

--- a/components/examples/command-palette.tsx
+++ b/components/examples/command-palette.tsx
@@ -146,7 +146,11 @@ const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "p") {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === "p"
+      ) {
         e.preventDefault();
         if (open) {
           closePalette();
@@ -167,7 +171,9 @@ const CommandPalette = ({ isAnimated = true }: CommandPaletteProps) => {
         closePalette();
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelectedIndex((i) => Math.min(i + 1, Math.max(0, filtered.length - 1)));
+        setSelectedIndex((i) =>
+          Math.min(i + 1, Math.max(0, filtered.length - 1)),
+        );
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setSelectedIndex((i) => Math.max(i - 1, 0));

--- a/lib/examples.ts
+++ b/lib/examples.ts
@@ -7,6 +7,7 @@ import TakeuforwardNavbar from "@/components/examples/takeuforward-navbar";
 import NotionSidebar from "@/components/examples/notion-sidebar";
 import Dock from "@/components/examples/dock";
 import ProfileDropdown from "@/components/examples/profile-dropdown";
+import CommandPalette from "@/components/examples/command-palette";
 
 // Define the registry of examples
 // Add new examples to this array
@@ -88,6 +89,16 @@ const EXAMPLE_REGISTRY = [
     description:
       "A sleek profile dropdown menu with animated icons, user information, and a theme toggle. ",
     tags: ["Dropdown", "Profile", "Navigation", "Framer Motion", "UI"],
+  },
+  {
+    componentName: "Command Palette",
+    slug: "command-palette",
+    createdBy: "https://github.com/itsaryanchauhan",
+    filePath: "components/examples/command-palette.tsx",
+    component: CommandPalette,
+    description:
+      "A VS Code-style command palette triggered by ⌘K. Features real-time search, keyboard navigation, grouped commands, and animated icons per result row.",
+    tags: ["Command Palette", "Search", "Keyboard", "Overlay", "Framer Motion"],
   },
 ];
 

--- a/lib/examples.ts
+++ b/lib/examples.ts
@@ -97,7 +97,7 @@ const EXAMPLE_REGISTRY = [
     filePath: "components/examples/command-palette.tsx",
     component: CommandPalette,
     description:
-      "A VS Code-style command palette triggered by ⌘K. Features real-time search, keyboard navigation, grouped commands, and animated icons per result row.",
+      "A VS Code-style command palette triggered by ⌘⇧P. Features real-time search, keyboard navigation, grouped commands, and animated icons per result row.",
     tags: ["Command Palette", "Search", "Keyboard", "Overlay", "Framer Motion"],
   },
 ];


### PR DESCRIPTION
## Description                 
                              
Adds a VS Code-style command palette example to showcase itshover animated icons in a real-world overlay UI pattern.                        
                              
## What's included       
                                                                                                                 
- Full-screen dimmed overlay triggered by `⌘⇧P` / `Ctrl+Shift+P`
- Real-time search filtering across 10 commands                                                                
- Grouped commands by category (Navigate, Actions, Account, Help)
- Keyboard navigation: `↑` / `↓` to move, `Enter` to select, `Escape` to close                                 
- Per-row icon hover animations using `ref.current?.startAnimation()`
- `isAnimated` toggle prop with `disableHover` support                                                         
- All icons imported from `../ui/` following repo conventions
                                          
## Type of Change                                                                                              
                              
- [x] New feature                                                                                              
                                                                                                                 
## Checklist                                                                                                   
                                                                                                                 
- [x] Code follows project style guidelines                                                                    
- [x] `npm run check` passes                                                                                   
- [x] Icons semantically match their labels                                                                    
- [x] `disableHover` passed when `isAnimated={false}`                                                          
- [x] Self-review completed             
                                  
Addresses #60  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command palette accessible via Ctrl/Cmd + Shift + P or a trigger button for quick command access.
  * Real-time search that filters commands by name and groups commands by category when not searching.
  * Keyboard navigation (Arrow keys) and selection with Enter; close with Escape or backdrop click.
  * Optional animated icons on hover/selection and selection events close the palette.

* **Chores**
  * Command palette added to the examples gallery for discovery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itshover/itshover/pull/143)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->