### PR TITLE
fix: correct package.json license to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "icons that move with intent",
   "author": "Abhij",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Description

The `license` field in `package.json` declares `"MIT"`, but every other license source in the repo says **Apache-2.0**:

- `LICENSE` → Apache License 2.0
- `CONTRIBUTING.md` → *"By contributing, you agree that your contributions will be licensed under the Apache 2.0 License."*
- GitHub repo metadata → Apache-2.0

This one-line change aligns the package metadata with the project's actual license, avoiding ambiguity for downstream consumers and license scanners.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New icon(s)
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Metadata-only change (no code paths affected; `npm run check` unaffected)
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project license from MIT to Apache-2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->