### PR TITLE
Remove CA address from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Its Hover
-CA: 0xAF257edDe898125FAD50016274455Bb6A3a8668A
 <a href="https://vercel.com/oss">
   <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge.svg" />
 </a>


### PR DESCRIPTION
Removed the CA address from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated line from the README, leaving the Vercel OSS badge as the next content under the “Its Hover” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->